### PR TITLE
Parse and handle Node update messages on UI

### DIFF
--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -6,12 +6,10 @@ function(set_project_warnings project_name)
 
   set(MSVC_WARNINGS
         /MP                     # Enable multi-processor compilation
+        /permissive-            # Enforce standards conformance
 
-        /experimental:external  # Enable external compiler options
         /external:anglebrackets # Treat all headers included via angle brackets as external headers
         /external:W0            # Turn off warnings for external headers
-
-        /permissive-            # Enforce standards conformance
 
         /W4     # Enable warning level 4
         /w14242 # 'identifier': conversion from 'type1' to 'type2', possible loss of data

--- a/src/data_model/include/data_types.hpp
+++ b/src/data_model/include/data_types.hpp
@@ -23,6 +23,30 @@ struct IO
         , value( ioValue )
     {}
 
+    IO( const IO& other )
+    {
+        id = other.id;
+        value = other.value;
+
+        if ( type != "Existing" )
+        {
+            type = other.type;
+        }
+    }
+
+    IO& operator=( IO rhs )
+    {
+        id = rhs.id;
+        value = rhs.value;
+
+        if ( rhs.type != "Existing" )
+        {
+            type = rhs.type;
+        }
+
+        return *this;
+    }
+
     IOId id;
     std::string type; // TODO: Change this to use the enum IOType
     int value;

--- a/src/messaging/include/messages.hpp
+++ b/src/messaging/include/messages.hpp
@@ -14,7 +14,7 @@ static const std::string endOfMessage = ">";
 enum class MessageType : char
 {
     NodeConnect = 'c',
-    Update = 'u',
+    NodeUpdate = 'u',
     Ack = 'a',
     Nak = 'n',
     UiConnect = 'g',

--- a/src/server/message_engine.cpp
+++ b/src/server/message_engine.cpp
@@ -116,7 +116,7 @@ void MessageEngine::MessageReceived( std::weak_ptr<Session>&& pSession, const st
         }
         break;
 
-        case MessageType::Update:
+        case MessageType::NodeUpdate:
         {
             if ( PeerConnected( pLockedSession ) )
             {
@@ -220,7 +220,7 @@ void MessageEngine::MessageReceived( std::weak_ptr<Session>&& pSession, const st
         }
         */
     }
-    catch ( const std::runtime_error& e )
+    catch ( const std::exception& e )
     {
         PrintWarning( "Failed to parse incoming message: ", e.what() );
         PrintDebug( "Message: \n", message );


### PR DESCRIPTION
* Implemented parsing and handling of update messages from Nodes on the UI.
* Fixed server to handle all std exceptions, not just runtime_error.
* Fixed parsing of node update messages that were incorrectly being rejected.
* Removed specification of experimental:external for compiler warnings. This is not needed for VS2019 16.10 and later.

Closes #21.